### PR TITLE
fix(test): exclude E2E tests from Vitest configuration (fixes #13)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,10 +7,19 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
+    exclude: ['**/node_modules/**', '**/e2e/**', '**/playwright/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/', 'src/test/', '**/*.d.ts', '**/*.config.*', '**/coverage/**'],
+      exclude: [
+        'node_modules/',
+        'src/test/',
+        '**/*.d.ts',
+        '**/*.config.*',
+        '**/coverage/**',
+        '.next/**',
+        'e2e/**',
+      ],
       thresholds: {
         global: {
           branches: 80,


### PR DESCRIPTION
## Summary
- Updated Vitest configuration to exclude E2E test directories
- Added exclusions for build artifacts in coverage settings
- Resolved conflict between Vitest and Playwright test runners

## Security Impact
None - test configuration improvement only.

## Testing
- [x] Linting passed (npm run lint)
- [x] Unit tests now run successfully without E2E conflicts
- [x] Coverage reporting fixed

## Breaking Changes
None - improves test separation and reliability.

Fixes #13